### PR TITLE
Cambiado appModule.productName por appModule.appName.

### DIFF
--- a/addon/globalPlugins/KillProcess.py
+++ b/addon/globalPlugins/KillProcess.py
@@ -51,7 +51,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
     # El método que se llama cuando se presiona la combinación de teclas
     def script_killProcess(self, gesture):  
         # Verificamos si el proceso enfocado actualmente es un proceso restringido
-        if api.getFocusObject().appModule.productName in ["NVDA", "explorer"]:  
+        if api.getFocusObject().appModule.appName in ["NVDA", "explorer"]:  
             # Notificamos al usuario que está enfocando un proceso restringido
             ui.message(_("Tiene enfocado un proceso restringido"))  
             return


### PR DESCRIPTION
He cambiado appModule.productName por appModule.appName en la línea 54.

En Windows 11 sí que mata el proceso Explorer porque productName no es "Explorer", como puedes ver a continuación.

> appModule: AppModule(explorer, appName='explorer', processID=9964)
> appModule.productName: 'Sistema operativo Microsoft® Windows®'

(Probado en Windows 11 22H2 (AMD64) build 22621.2428)

Además, appName es más seguro porque productName a veces falla con algunas aplicaciones y da este error:

>  File "C:\Users\JaviD\AppData\Roaming\nvda\addons\killProcess\globalPlugins\KillProcess.py", line 54, in script_killProcess
>    if api.getFocusObject().appModule.productName in ["NVDA", "explorer"]:
>  File "baseObject.pyc", line 41, in __get__
>  File "appModuleHandler.pyc", line 574, in _get_productName
>  File "appModuleHandler.pyc", line 551, in _setProductInfo
>RuntimeError: processHandle is 0
