### PR TITLE
Update translations fr, en and it

### DIFF
--- a/addon/locale/en/LC_MESSAGES/nvda.po
+++ b/addon/locale/en/LC_MESSAGES/nvda.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: killProcess 1.2\n"
 "Report-Msgid-Bugs-To: nvda-translations@groups.io\n"
 "POT-Creation-Date: 2023-12-04 09:42-0600\n"
-"PO-Revision-Date: 2023-12-04 11:25-0600\n"
+"PO-Revision-Date: 2024-04-05 10:43+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.4.1\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. Descripción del comando del teclado que mata el proceso enfocado
@@ -27,7 +27,7 @@ msgstr "Kills the currently focused process."
 #. Notificamos al usuario que está enfocando un proceso restringido
 #: addon\globalPlugins\KillProcess.py:59
 msgid "Tiene enfocado un proceso restringido"
-msgstr "It has a restricted process focused"
+msgstr "A restricted process is focused"
 
 #. Notificamos al usuario que el proceso no pudo ser matado
 #: addon\globalPlugins\KillProcess.py:69

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: 'killProcess' '1.2'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
 "POT-Creation-Date: 2023-12-04 08:48+0100\n"
-"PO-Revision-Date: 2023-12-04 08:55+0100\n"
+"PO-Revision-Date: 2024-04-05 10:47+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. Descripción del comando del teclado que mata el proceso enfocado
@@ -27,7 +27,7 @@ msgstr "Tue le processus actuellement ciblé."
 #. Notificamos al usuario que está enfocando un proceso restringido
 #: addon\globalPlugins\KillProcess.py:59
 msgid "Tiene enfocado un proceso restringido"
-msgstr "Il a un processus restreint axé"
+msgstr "Un processus restreint a le focus"
 
 #. Notificamos al usuario que el proceso no pudo ser matado
 #: addon\globalPlugins\KillProcess.py:69
@@ -56,7 +56,7 @@ msgstr "{} a été fermé avec succès"
 #. Manager.
 #: buildVars.py:23
 msgid "Kill Process"
-msgstr "Processus de mise à mort"
+msgstr "Termine le processus"
 
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on

--- a/addon/locale/it/LC_MESSAGES/nvda.po
+++ b/addon/locale/it/LC_MESSAGES/nvda.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: 'killProcess' '1.2'\n"
 "Report-Msgid-Bugs-To: 'nvda-translations@groups.io'\n"
 "POT-Creation-Date: 2023-12-04 08:48+0100\n"
-"PO-Revision-Date: 2023-12-04 08:55+0100\n"
+"PO-Revision-Date: 2024-04-05 10:48+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 3.3.1\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. Descripción del comando del teclado que mata el proceso enfocado
@@ -27,7 +27,7 @@ msgstr "Uccide il processo attualmente focalizzato."
 #. Notificamos al usuario que está enfocando un proceso restringido
 #: addon\globalPlugins\KillProcess.py:59
 msgid "Tiene enfocado un proceso restringido"
-msgstr "Ha un processo ristretto focalizzato"
+msgstr "Un processo ristretto è focalizzato"
 
 #. Notificamos al usuario que el proceso no pudo ser matado
 #: addon\globalPlugins\KillProcess.py:69


### PR DESCRIPTION
### Issue
The name of the add-on in French is "Processus de mise à mort", which would be "Process to put someone to death" in English or "proceso de matanza" in Spanish.
Make me wonder if it has something to do with the guillautin or the electric chair!

### Solution
Fixed the name in French.

Also fixed another string which was quite ununderstandable in English, French and Italian. I cannot say for the other languages since I do not speak them but it would be nice to double check them.

